### PR TITLE
Add the getGroup() method to SentryConfigOptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,10 @@ Setup
 -----
 
 1. Drop the code into phabricator/src/extensions/
-2. Configure Sentry via http://phabricator.example.com/config/group/sentryconfigoptions/
-3. Enjoy errors being reported to Sentry.
+2. Install the `raven-php <https://github.com/getsentry/raven-php>`_ library somewhere on your machine.
+3. Ensure that ``path/to/raven-php/lib`` is in your PHP ``include_path``.
+4. Configure Sentry via http://phabricator.example.com/config/group/sentryconfigoptions/
+5. Enjoy errors being reported to Sentry.
 
 Contributing
 ------------

--- a/src/sentrylogger/SentryConfigOptions.php
+++ b/src/sentrylogger/SentryConfigOptions.php
@@ -6,6 +6,10 @@ final class SentryConfigOptions extends PhabricatorApplicationConfigOptions {
     return pht('Sentry');
   }
 
+  public function getGroup() {
+    return pht('apps');
+  }
+
   public function getDescription() {
     return pht('Configure Sentry builds.');
   }

--- a/src/sentrylogger/SentryLoggerRegistration.php
+++ b/src/sentrylogger/SentryLoggerRegistration.php
@@ -8,6 +8,8 @@ class SentryLoggerRegistration extends PhabricatorAutoEventListener {
       return;
     }
 
+    // Make sure `raven-php/lib` is in your `include_path`.
+    require_once 'Raven/Autoloader.php';
     Raven_Autoloader::register();
 
     // Configure the client


### PR DESCRIPTION
Phabricator has updated their API, and on modern versions extending the `PhabricatorApplicationConfigOptions` abstract class requires defining a `getGroup()` method.

In addition, I found that I needed to require the Raven library to make this work on our instance.

Finally, while I was at it, I touched up the docs.
